### PR TITLE
Optimize RSS feed to show only 4 most recent notes

### DIFF
--- a/src/rss.html
+++ b/src/rss.html
@@ -15,7 +15,7 @@ permalink: "/feed.xml"
     <name>{{ site.authorName }}</name>
     <email>{{ site.authorEmail }}</email>
 	</author>
-	{% for note in collections.notes %}
+	{% for note in collections.notesFeed %}
     {% set absolutePostUrl %}{{ site.url }}{{ note.url | url }}{% endset %}
     <entry>
       <title>{{ note.data.title }}</title>


### PR DESCRIPTION
This change updates the RSS feed template to use collections.notesFeed instead of collections.notes, limiting the feed to the 4 most recent notes instead of all 78 notes. This reduces feed size and follows standard RSS best practices.

Closes ##8

Generated with [Claude Code](https://claude.ai/code)